### PR TITLE
chore: sync Homebrew frontend and lock inputs

### DIFF
--- a/.github/workflows/update-homebrew-lock.yml
+++ b/.github/workflows/update-homebrew-lock.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
 
       - name: Update Homebrew inputs
-        run: nix flake update homebrew-core homebrew-cask homebrew-bundle nix-homebrew
+        run: nix flake update brew-src homebrew-core homebrew-cask homebrew-bundle nix-homebrew
 
       - name: Commit and push if changed
         run: |

--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,15 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1774235677,
-        "narHash": "sha256-0ryNYmzDAeRlrzPTAgmzGH/Cgc8iv/LBN6jWGUANvIk=",
+        "lastModified": 1775583540,
+        "narHash": "sha256-pBrHDIKwlv8HsA/nkHM4DXDsnClKRpIHu2NfQ2gy+2U=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "894a3d23ac0c8aaf561b9874b528b9cb2e839201",
+        "rev": "9f7d5c562c205738d7ea3dedb9072f1e7e6ff382",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "5.1.1",
         "repo": "brew",
         "type": "github"
       }
@@ -75,11 +74,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1775539955,
-        "narHash": "sha256-jVS9kkf+Y4FUfu5ltzq4jwlEx1N7+cvRSwdk7ux75+g=",
+        "lastModified": 1775591339,
+        "narHash": "sha256-SMmm1u5o53YUo7cWtr85lxuF730rscom3PHdVYPiMoo=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "fc060312dd0dd57e6444a456add5d4db9489c9cc",
+        "rev": "391c232f0522d2495fc0e9784d4f5de8fb70aacf",
         "type": "github"
       },
       "original": {
@@ -91,11 +90,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1775541300,
-        "narHash": "sha256-L0aiApqeaJfHEgFZs1Ngr3UQE5vya2bW0ryfd8GMCxo=",
+        "lastModified": 1775589788,
+        "narHash": "sha256-VlRADs3fhf0NNyYnYyQMnvAk84pNQT6F3VNAMp01FAE=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "7e3c00c013fe3f2703669b8a651fe7b9ba61a067",
+        "rev": "c4ac0a85880c68ec353be7ff156d4e94b7c1ea8d",
         "type": "github"
       },
       "original": {
@@ -127,7 +126,9 @@
     },
     "nix-homebrew": {
       "inputs": {
-        "brew-src": "brew-src"
+        "brew-src": [
+          "brew-src"
+        ]
       },
       "locked": {
         "lastModified": 1774720267,
@@ -177,6 +178,7 @@
     },
     "root": {
       "inputs": {
+        "brew-src": "brew-src",
         "flake-utils": "flake-utils",
         "home-manager": "home-manager",
         "homebrew-bundle": "homebrew-bundle",

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,14 @@
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
 
+    # Keep the Homebrew frontend in sync with the moving core/cask taps.
+    brew-src = {
+      url = "github:Homebrew/brew";
+      flake = false;
+    };
+
     nix-homebrew.url = "github:zhaofengli/nix-homebrew";
+    nix-homebrew.inputs.brew-src.follows = "brew-src";
     homebrew-core = {
       url = "github:homebrew/homebrew-core";
       flake = false;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: updates Nix flake inputs/lockfile and CI automation for Homebrew sources, with impact limited to dependency pinning and reproducibility.
> 
> **Overview**
> Keeps Homebrew’s frontend (`Homebrew/brew`) pinned and updated alongside the Homebrew taps by introducing a dedicated `brew-src` flake input and wiring `nix-homebrew.inputs.brew-src.follows = "brew-src"`.
> 
> Updates the scheduled GitHub Action to run `nix flake update` for `brew-src` as well, and refreshes `flake.lock` with new revisions/hashes for `brew-src`, `homebrew-core`, and `homebrew-cask` (plus the corresponding input graph change in `flake.lock`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3334a1be077164db69112c2cbced64084cba0e91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->