### PR TITLE
chore: add bun to shared home packages

### DIFF
--- a/shared/home.nix
+++ b/shared/home.nix
@@ -28,6 +28,7 @@
     pkgs.neovim
 
     pkgs.nodejs_22
+    pkgs.bun
 
     pkgs-unstable.python314
     pkgs-unstable.python314Packages.pip


### PR DESCRIPTION
## Summary
- Add `pkgs.bun` to `shared/home.nix` alongside `pkgs.nodejs_22`

## Test plan
- [ ] `nix flake check`
- [ ] Rebuild a workstation and verify `bun --version` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)